### PR TITLE
Merchant item count test

### DIFF
--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -94,5 +94,48 @@ RSpec.describe "Merchants API" do
       expect(data[:errors].first[:status]).to eq("422")
       expect(data[:errors].first[:message]).to eq("Couldn't find Merchant with 'id'=#{missing_id}") 
     end
+
+    it "includes and item count when asked" do
+      @item1 = Item.create(
+      name: "Catnip Toy",
+      description: "A soft toy filled with catnip.",
+      unit_price: 12.99,
+      merchant_id: @merchant1.id
+      )
+      @item2 = Item.create(
+      name: "Laser Pointer",
+      description: "A laser pointer to keep your cat active.",
+      unit_price: 9.99,
+      merchant_id: @merchant1.id
+      )
+
+      get "/api/v1/merchants?count=true"
+      expect(response).to be_successful
+
+      merchants = JSON.parse(response.body)
+
+      expect(merchants["data"].count).to eq(4)
+      merchants["data"].each do |merchant|
+        expect(merchant).to have_key("id")
+        expect(merchant["attributes"]).to have_key("name")
+        expect(merchant["attributes"]).to have_key("item_count")
+
+        individual_merchant = Merchant.find(merchant["id"].to_i)
+        expect(merchant["attributes"]["item_count"]).to eq(individual_merchant.items.count)
+      end
+    end
+
+    it "does not include item count when not asked for" do
+      get "/api/v1/merchants"
+      expect(response).to be_successful
+    
+      merchants = JSON.parse(response.body)
+    
+      expect(merchants["data"].count).to eq(4)
+      merchants["data"].each do |merchant|
+        expect(merchant["attributes"]).to have_key("name")
+        expect(merchant["attributes"]).to_not have_key("item_count")
+      end
+    end
   end
 end


### PR DESCRIPTION
- Added tests to the merchant request spec file for if the item count query is present it returns that merchants item count, and if the query is not present, it does not include the item count key or value in the json response.